### PR TITLE
Add theme toggle to fonts.html

### DIFF
--- a/fonts.html
+++ b/fonts.html
@@ -6,11 +6,17 @@
   <title>Font Reference — Kismulet Architecture</title>
   <style>
     body {
-      background-color: #0a0a0a;
-      color: #fff;
       font-family: sans-serif;
       padding: 2rem;
       line-height: 1.6;
+    }
+    body.light-theme {
+      background-color: #ffffff;
+      color: #000000;
+    }
+    body.dark-theme {
+      background-color: #0a0a0a;
+      color: #ffffff;
     }
     h1 {
       font-size: 2rem;
@@ -55,6 +61,7 @@
 <body>
   <main>
     <h1>🧬 Typography Gradient Test — architecture.kismulet.org</h1>
+    <button onclick="cycleTheme()">🌓 Change Theme</button>
 
     <section>
       <h2>Primary</h2>
@@ -76,5 +83,6 @@
       <p class="superintegral">sometimes, even a whisper becomes a thread.</p>
     </section>
   </main>
+  <script src="theme_toggle_script.js"></script>
 </body>
 </html>

--- a/theme_toggle_script.js
+++ b/theme_toggle_script.js
@@ -1,0 +1,19 @@
+(function() {
+  const themes = ['light-theme', 'dark-theme'];
+  function setBodyClass(theme) {
+    document.body.classList.remove(...themes);
+    document.body.classList.add(theme);
+    localStorage.setItem('theme', theme);
+  }
+
+  window.cycleTheme = function() {
+    const current = localStorage.getItem('theme') || 'light-theme';
+    const next = current === 'light-theme' ? 'dark-theme' : 'light-theme';
+    setBodyClass(next);
+  };
+
+  document.addEventListener('DOMContentLoaded', function() {
+    const savedTheme = localStorage.getItem('theme') || 'light-theme';
+    setBodyClass(savedTheme);
+  });
+})();


### PR DESCRIPTION
## Summary
- add theme toggle button in `fonts.html`
- support light and dark theme classes
- create `theme_toggle_script.js` to persist preference and handle switching
- load the toggle script in the HTML

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a02912ab0832fbd7da6cb19f9decd