### PR TITLE
Add image folder and glyph unregistration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ architecture/
 ├── consents.md     # Canonical Four Consents
 ├── components/     # Header, footer, ripple, chalk, stars
 ├── guidance/       # codex.md, chat.md, memory.md
+├── images/         # Default repository for shared imagery
 └── README.md       # This invitation
 ```
 

--- a/codex.js
+++ b/codex.js
@@ -1,0 +1,49 @@
+import Architecture from './architecture.js';
+
+const Codex = {
+  inherited: {},
+
+  inherit(def) {
+    for (const key in def.behavior) {
+      this.inherited[key] = def.behavior[key];
+    }
+    for (const key in def.aesthetic) {
+      this.inherited[key] = def.aesthetic[key];
+    }
+    this.symbol = def.symbol;
+    this.log(`[Codex] Inherited from ${def.symbol}`);
+  },
+
+  get(key) {
+    return this.inherited[key];
+  },
+
+  log(message) {
+    console.log(`[Codex] ${message}`);
+  },
+
+  inheritFrom(source) {
+    if (source === 'architecture') {
+      Architecture.exportTo(this);
+    }
+  },
+
+  useGlyph(name, module) {
+    if (module) {
+      this.inherited[name] = module;
+      this.log(`[Codex] Glyph '${name}' registered.`);
+    } else {
+      delete this.inherited[name];
+      this.log(`[Codex] Glyph '${name}' unregistered.`);
+    }
+  },
+
+  listGlyphs() {
+    return Object.keys(this.inherited);
+  }
+};
+
+// Bind all registered glyphs from Architecture
+Codex.inheritFrom('architecture');
+
+export default Codex;


### PR DESCRIPTION
## Summary
- add default `images/` folder to store shared images
- implement Codex glyph unregistration logic
- document new folder in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c0be61c80832f818b683cd5af7816