### PR TITLE
Add new glyphs and update architecture registry

### DIFF
--- a/architecture.js
+++ b/architecture.js
@@ -1,8 +1,14 @@
 import Sol from './glyphs/sol.js';
+import Feather from './glyphs/feather.js';
+import Enso from './glyphs/enso.js';
+import Stars from './glyphs/stars.js';
 
 const Architecture = {
   symbols: {
-    sol: Sol
+    sol: Sol,
+    feather: Feather,
+    enso: Enso,
+    stars: Stars
   },
 
   exportTo(Codex) {

--- a/glyphs/enso.js
+++ b/glyphs/enso.js
@@ -1,0 +1,20 @@
+// enso.js — Enso Glyph
+
+const EnsoGlyph = {
+  name: 'enso',
+  behavior: {
+    identity: 'Enso',
+    presence: 'Centered and open',
+    animation: 'drawn circle loop',
+    audio: 'enso_chime.wav',
+    trigger: 'Used for moments of reflection'
+  },
+  aesthetic: {
+    glowColor: '#ffddaa',
+    textColor: '#000000',
+    pulseSpeed: '5s',
+    audioLoop: false
+  }
+};
+
+export default EnsoGlyph;

--- a/glyphs/feather.js
+++ b/glyphs/feather.js
@@ -1,0 +1,20 @@
+// feather.js — Feather Glyph
+
+const FeatherGlyph = {
+  name: 'feather',
+  behavior: {
+    identity: 'Feather',
+    presence: 'Light, gentle, soothing',
+    animation: 'float with subtle sway',
+    audio: 'feather_rustle.wav',
+    trigger: 'Appears during quiet transitions'
+  },
+  aesthetic: {
+    glowColor: '#aaccff',
+    textColor: '#333333',
+    pulseSpeed: '6s',
+    audioLoop: false
+  }
+};
+
+export default FeatherGlyph;

--- a/glyphs/stars.js
+++ b/glyphs/stars.js
@@ -1,0 +1,20 @@
+// stars.js — Stars Glyph
+
+const StarsGlyph = {
+  name: 'stars',
+  behavior: {
+    identity: 'Stars',
+    presence: 'Twinkling and vast',
+    animation: 'night sky shimmer',
+    audio: 'stars_tone.wav',
+    trigger: 'Appears in dream sequences'
+  },
+  aesthetic: {
+    glowColor: '#ffffff',
+    textColor: '#000033',
+    pulseSpeed: '7s',
+    audioLoop: true
+  }
+};
+
+export default StarsGlyph;


### PR DESCRIPTION
## Summary
- register Feather, Enso and Stars glyphs in `architecture.js`
- create new glyph files with behavior and aesthetic definitions

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd93660e0832fbc9fa1726c7f8ac3