### PR TITLE
Refactor glyph modules to named exports

### DIFF
--- a/architecture.js
+++ b/architecture.js
@@ -1,4 +1,4 @@
-import Sol from './glyphs/sol.js';
+import { Sol } from './glyphs/sol.js';
 
 const Architecture = {
   symbols: {

--- a/glyphs/enso.js
+++ b/glyphs/enso.js
@@ -1,4 +1,4 @@
-export default {
+export const Enso = {
   name: 'enso',
   render: (opts = {}) => {
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')

--- a/glyphs/feather.js
+++ b/glyphs/feather.js
@@ -1,4 +1,4 @@
-export default {
+export const Feather = {
   name: 'feather',
   render: (opts = {}) => {
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')

--- a/glyphs/glyphs.js
+++ b/glyphs/glyphs.js
@@ -1,7 +1,7 @@
-import Feather from './feather.js'
-import Enso from './enso.js'
-import Stars from './stars.js'
-import Sol from './sol.js'
+import { Feather } from './feather.js'
+import { Enso } from './enso.js'
+import { Stars } from './stars.js'
+import { Sol } from './sol.js'
 
 export const GlyphRegistry = {
   feather: Feather,

--- a/glyphs/index.html
+++ b/glyphs/index.html
@@ -1,0 +1,53 @@
+export const GlyphPreviewHTML = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Glyphs – architecture.kismulet.org</title>
+  <style>
+    body {
+      background: #000;
+      color: white;
+      font-family: Georgia, serif;
+      text-align: center;
+      padding: 2rem;
+    }
+    .glyph {
+      margin: 2rem auto;
+      display: block;
+    }
+    .glyph-label {
+      margin-top: 0.5rem;
+      font-size: 1rem;
+      opacity: 0.6;
+    }
+  </style>
+</head>
+<body>
+  <h1>Glyph Registry</h1>
+  <div id="glyph-container"></div>
+
+  <script type="module">
+    import { GlyphRegistry, renderGlyph } from './glyphs.js'
+
+    const container = document.getElementById('glyph-container')
+
+    Object.keys(GlyphRegistry).forEach(type => {
+      const glyph = renderGlyph(type)
+      if (glyph) {
+        const wrapper = document.createElement('div')
+        wrapper.appendChild(glyph)
+
+        const label = document.createElement('div')
+        label.textContent = type
+        label.className = 'glyph-label'
+
+        wrapper.appendChild(label)
+        container.appendChild(wrapper)
+      }
+    })
+  </script>
+</body>
+</html>
+`

--- a/glyphs/sol.js
+++ b/glyphs/sol.js
@@ -1,4 +1,4 @@
-export default {
+export const Sol = {
   name: 'sol',
   render: (opts = {}) => {
     const div = document.createElement('div')

--- a/glyphs/stars.js
+++ b/glyphs/stars.js
@@ -1,4 +1,4 @@
-export default {
+export const Stars = {
   name: 'stars',
   render: (opts = {}) => {
     const canvas = document.createElement('canvas')


### PR DESCRIPTION
## Summary
- convert glyph modules to named exports
- update registry and architecture to use named imports
- add GlyphPreviewHTML template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d8bb1d3a4832f9040ddecc5d5b058