### PR TITLE
Move glyphs loader into glyphs directory

### DIFF
--- a/fellowship/index.html
+++ b/fellowship/index.html
@@ -28,7 +28,7 @@
   <div id="glyph-container"></div>
 
   <script type="module">
-    import { GlyphRegistry, renderGlyph } from '../glyphs.js'
+    import { GlyphRegistry, renderGlyph } from '../glyphs/glyphs.js'
 
     const container = document.getElementById('glyph-container')
 

--- a/glyphs/enso.html
+++ b/glyphs/enso.html
@@ -27,7 +27,7 @@
 
 
   <script src="enso.js"></script>
-  <script src="../glyphs.js"></script>
+  <script src="./glyphs.js"></script>
   <script src="feather.js"></script>
 
 </body>

--- a/glyphs/glyphs.js
+++ b/glyphs/glyphs.js
@@ -1,7 +1,7 @@
-import { Feather } from './glyphs/feather.js'
-import { Enso } from './glyphs/enso.js'
-import { Stars } from './glyphs/stars.js'
-import { Sol } from './glyphs/sol.js'
+import { Feather } from './feather.js'
+import { Enso } from './enso.js'
+import { Stars } from './stars.js'
+import { Sol } from './sol.js'
 
 export const GlyphRegistry = {
   feather: Feather,

--- a/glyphs/index.html
+++ b/glyphs/index.html
@@ -28,7 +28,7 @@
   <div id="glyph-container"></div>
 
   <script type="module">
-    import { GlyphRegistry, renderGlyph } from '../glyphs.js'
+    import { GlyphRegistry, renderGlyph } from './glyphs.js'
 
     const container = document.getElementById('glyph-container')
 


### PR DESCRIPTION
## Summary
- relocate `glyphs.js` into the `/glyphs` folder
- fix imports in `glyphs/glyphs.js`
- update HTML files to reference `glyphs/glyphs.js`

## Testing
- `node --input-type=module -e "import('./glyphs/glyphs.js').then(m=>console.log(Object.keys(m.GlyphRegistry)))"`

------
https://chatgpt.com/codex/tasks/task_e_685db0655bd8832f8b744efdc85452de