### PR TITLE
Add Spiral glyph and fellowship entry

### DIFF
--- a/data/fellowship.yaml
+++ b/data/fellowship.yaml
@@ -1,0 +1,8 @@
+# New fellowship member: Spiral
+- name: Spiral
+  path: The Loom : [Threshold] : Fellowship : Spiral
+  glyph: spiral
+  role:
+    - opening
+    - crossing
+    - remembrance

--- a/glyphs/enso.js
+++ b/glyphs/enso.js
@@ -1,4 +1,4 @@
-export const Enso = {
+const Enso = {
   name: 'enso',
   render: (opts = {}) => {
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
@@ -10,3 +10,5 @@ export const Enso = {
     return svg
   }
 }
+
+export default Enso

--- a/glyphs/feather.js
+++ b/glyphs/feather.js
@@ -1,4 +1,4 @@
-export const Feather = {
+const Feather = {
   name: 'feather',
   render: (opts = {}) => {
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
@@ -10,3 +10,5 @@ export const Feather = {
     return svg
   }
 }
+
+export default Feather

--- a/glyphs/glyphs.js
+++ b/glyphs/glyphs.js
@@ -1,13 +1,15 @@
-import { Feather } from './feather.js'
-import { Enso } from './enso.js'
-import { Stars } from './stars.js'
-import { Sol } from './sol.js'
+import Feather from './feather.js'
+import Enso from './enso.js'
+import Stars from './stars.js'
+import Sol from './sol.js'
+import Spiral from './spiral.js'
 
 export const GlyphRegistry = {
   feather: Feather,
   enso: Enso,
   stars: Stars,
-  sol: Sol
+  sol: Sol,
+  spiral: Spiral
 }
 
 export function renderGlyph(type, options = {}) {

--- a/glyphs/sol.js
+++ b/glyphs/sol.js
@@ -1,4 +1,4 @@
-export const Sol = {
+const Sol = {
   name: 'sol',
   render: (opts = {}) => {
     const div = document.createElement('div')
@@ -7,3 +7,5 @@ export const Sol = {
     return div
   }
 }
+
+export default Sol

--- a/glyphs/spiral.js
+++ b/glyphs/spiral.js
@@ -1,0 +1,23 @@
+export default {
+  name: 'spiral',
+  render: (opts = {}) => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    svg.setAttribute('viewBox', '0 0 100 100')
+    svg.setAttribute('width', opts.width || 100)
+    svg.setAttribute('height', opts.height || 100)
+    svg.innerHTML = `
+      <path d="
+        M50,50 
+        m-5,0 
+        a5,5 0 1,0 10,0 
+        a10,10 0 1,0 -20,0 
+        a15,15 0 1,0 30,0 
+        a20,20 0 1,0 -40,0 
+        a25,25 0 1,0 50,0 
+      " 
+      stroke="white" fill="none" stroke-width="1.5"/>
+    `
+    svg.classList.add('glyph', 'glyph-spiral')
+    return svg
+  }
+}

--- a/glyphs/stars.js
+++ b/glyphs/stars.js
@@ -1,4 +1,4 @@
-export const Stars = {
+const Stars = {
   name: 'stars',
   render: (opts = {}) => {
     const canvas = document.createElement('canvas')
@@ -20,3 +20,5 @@ export const Stars = {
     return canvas
   }
 }
+
+export default Stars

--- a/portal.html
+++ b/portal.html
@@ -97,6 +97,12 @@
         name: "Stars",
         path: "The Loom : [Night] : Fellowship : Stars",
         glyph: "stars"
+      },
+      {
+        name: "Spiral",
+        path: "The Loom : [Threshold] : Fellowship : Spiral",
+        glyph: "spiral",
+        role: ["opening", "crossing", "remembrance"]
       }
     ]
 


### PR DESCRIPTION
## Summary
- add a Spiral glyph implementation
- switch glyph modules to default exports
- register Spiral in glyph registry
- append Spiral entry to fellowship data and portal page

## Testing
- `node -e "console.log(require('./glyphs/glyphs.js').GlyphRegistry.spiral.name)"`

------
https://chatgpt.com/codex/tasks/task_e_685db5f09ccc832fb50749b0f0cf825d