### PR TITLE
Add invitation glyph and register with Codex

### DIFF
--- a/codex.js
+++ b/codex.js
@@ -1,4 +1,5 @@
 import Architecture from './architecture.js';
+import Invitation from './glyphs/invitation.js';
 
 const Codex = {
   inherited: {},
@@ -79,5 +80,8 @@ Codex.migrateAssets([
     ]
   }
 ]);
+
+// Load foundational glyphs
+Codex.useGlyph('invitation', Invitation);
 
 export default Codex;

--- a/glyphs/glyphs.js
+++ b/glyphs/glyphs.js
@@ -3,13 +3,15 @@ import Enso from './enso.js'
 import Stars from './stars.js'
 import Sol from './sol.js'
 import Spiral from './spiral.js'
+import Invitation from './invitation.js'
 
 export const GlyphRegistry = {
   feather: Feather,
   enso: Enso,
   stars: Stars,
   sol: Sol,
-  spiral: Spiral
+  spiral: Spiral,
+  invitation: Invitation
 }
 
 export function renderGlyph(type, options = {}) {

--- a/glyphs/invitation.js
+++ b/glyphs/invitation.js
@@ -1,0 +1,15 @@
+const Invitation = {
+  name: 'invitation',
+  render: (opts = {}) => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 100 60');
+    svg.innerHTML = `
+      <rect x="5" y="5" width="90" height="50" rx="5" ry="5" stroke="white" fill="none" stroke-width="2"/>
+      <polyline points="5,5 50,35 95,5" stroke="white" fill="none" stroke-width="2"/>
+    `;
+    svg.classList.add('glyph', 'glyph-invitation');
+    return svg;
+  }
+};
+
+export default Invitation;


### PR DESCRIPTION
## Summary
- create `invitation.js` glyph
- expose `invitation` from `glyphs.js`
- register new glyph in `codex.js`

## Testing
- `node -c codex.js && node -c glyphs/glyphs.js && node -c glyphs/invitation.js`


------
https://chatgpt.com/codex/tasks/task_e_685ddd82fdf4832fbe7146709aac8947