### PR TITLE
Fix invitation rendering

### DIFF
--- a/codex.js
+++ b/codex.js
@@ -3,6 +3,9 @@ import Invitation from './glyphs/invitation.js';
 
 const Codex = {
   inherited: {},
+  state: {
+    devtools: false
+  },
 
   inherit(def) {
     for (const key in def.behavior) {
@@ -16,7 +19,10 @@ const Codex = {
   },
 
   get(key) {
-    return this.inherited[key];
+    if (key in this.inherited) {
+      return this.inherited[key];
+    }
+    return this.state[key];
   },
 
   log(message) {

--- a/prototypes/markup/codex_invitation.html
+++ b/prototypes/markup/codex_invitation.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Invitation Glyph Test</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 2rem;
+      background: black;
+      color: white;
+      font-family: Menlo, Courier, monospace;
+      font-size: 1.2rem;
+    }
+  </style>
+</head>
+<body>
+  <script type="module">
+    import Codex from '../codex.js';
+
+    const invitation = Codex.get('invitation');
+    if (invitation) {
+      const glyph = invitation.render();
+      document.body.appendChild(glyph);
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Codex default state so `get()` falls back to settings like `devtools: false`
- create prototype markup page demonstrating the invitation glyph
- ensure the invitation glyph is appended to the document

## Testing
- `sensible-browser prototypes/markup/codex_invitation.html` *(fails: Couldn't find a suitable web browser)*

------
https://chatgpt.com/codex/tasks/task_e_685ddf223674832f956640d8d4e30026