### PR TITLE
Add Echo glyph

### DIFF
--- a/glyphs/echo.js
+++ b/glyphs/echo.js
@@ -1,0 +1,50 @@
+const Echo = {
+  name: 'echo',
+
+  config: {
+    seed: 'imagine',
+    numechoes: 4,
+    direction: 'down-right', // up, down, left, right, up-left, up-right, down-left, down-right
+    fadeMode: 'light-to-dark',
+    baseColor: 'rgba(0, 0, 0, 1)',
+    echoColor: 'rgba(0, 0, 0, FADE)', // FADE will be replaced dynamically
+    containerId: 'echo-field'
+  },
+
+  render(custom = {}) {
+    const cfg = { ...this.config, ...custom }
+    const container = document.getElementById(cfg.containerId)
+    if (!container) return
+    container.style.position = 'relative'
+    container.style.fontFamily = 'Menlo, Courier, monospace'
+    container.style.whiteSpace = 'pre'
+
+    const directions = {
+      up: [0, -1],
+      down: [0, 1],
+      left: [-1, 0],
+      right: [1, 0],
+      'up-left': [-1, -1],
+      'up-right': [1, -1],
+      'down-left': [-1, 1],
+      'down-right': [1, 1]
+    }
+    const [dx, dy] = directions[cfg.direction]
+
+    for (let i = 0; i <= cfg.numechoes; i++) {
+      const word = document.createElement('span')
+      word.innerText = cfg.seed
+      word.style.position = 'absolute'
+      word.style.left = `${dx * i}em`
+      word.style.top = `${dy * i}em`
+      word.style.opacity = 1 - i / (cfg.numechoes + 1)
+      const fadeVal = cfg.fadeMode === 'light-to-dark'
+        ? 1 - i / (cfg.numechoes + 1)
+        : i / (cfg.numechoes + 1)
+      word.style.color = cfg.echoColor.replace('FADE', fadeVal.toFixed(2))
+      container.appendChild(word)
+    }
+  }
+}
+
+export default Echo

--- a/glyphs/glyphs.js
+++ b/glyphs/glyphs.js
@@ -4,6 +4,7 @@ import Stars from './stars.js'
 import Sol from './sol.js'
 import Spiral from './spiral.js'
 import Invitation from './invitation.js'
+import Echo from './echo.js'
 
 export const GlyphRegistry = {
   feather: Feather,
@@ -11,7 +12,8 @@ export const GlyphRegistry = {
   stars: Stars,
   sol: Sol,
   spiral: Spiral,
-  invitation: Invitation
+  invitation: Invitation,
+  echo: Echo
 }
 
 export function renderGlyph(type, options = {}) {


### PR DESCRIPTION
## Summary
- add a new glyph `Echo` for text echo visualizations
- register `Echo` in the glyph registry

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685efc1a8aa8832f8aa8a18911431b86