### PR TITLE
Add Sol glyph metadata and iamsol animation

### DIFF
--- a/glyphs/iamsol.js
+++ b/glyphs/iamsol.js
@@ -1,42 +1,66 @@
 export default {
   name: 'iamsol',
+  behavior: {
+    identity: 'Sol',
+    presence: 'glowing warmth',
+    gesture: 'radiant expansion',
+    motion: 'breathing light',
+    meaning: 'illumination'
+  },
   render: (opts = {}) => {
+    const size = opts.size || 300
     const canvas = document.createElement('canvas')
-    const width = opts.width || 300
-    const height = opts.height || width
-    canvas.width = width
-    canvas.height = height
+    canvas.width = size
+    canvas.height = size
     canvas.classList.add('glyph', 'glyph-iamsol')
 
     const ctx = canvas.getContext('2d')
 
-    let animationFrame
-    const baseRadius = Math.min(width, height) * 0.3
-    const maxJitter = baseRadius * 0.1
+    let frameId
+    const baseRadius = size * 0.3
+    const jitter = baseRadius * 0.15
+    const rays = 12
 
     function draw(t) {
       const time = t / 1000
-      const radius = baseRadius + Math.sin(time) * maxJitter
-      ctx.clearRect(0, 0, width, height)
+      ctx.clearRect(0, 0, size, size)
 
-      const cx = width / 2
-      const cy = height / 2
+      const radius = baseRadius + Math.sin(time * 2) * jitter
+      const cx = size / 2
+      const cy = size / 2
+
       const gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, radius)
       gradient.addColorStop(0, 'rgba(255, 204, 0, 1)')
-      gradient.addColorStop(0.6, 'rgba(255, 153, 0, 0.8)')
+      gradient.addColorStop(0.7, 'rgba(255, 153, 0, 0.8)')
       gradient.addColorStop(1, 'rgba(255, 102, 0, 0)')
 
       ctx.fillStyle = gradient
-      ctx.fillRect(0, 0, width, height)
+      ctx.fillRect(0, 0, size, size)
+
+      ctx.save()
+      ctx.translate(cx, cy)
+      ctx.strokeStyle = 'rgba(255, 180, 0, 0.5)'
+      ctx.lineWidth = 2
+
+      for (let i = 0; i < rays; i++) {
+        const angle = (i / rays) * Math.PI * 2 + time * 0.3
+        const len = radius * 1.4 + Math.sin(time * 3 + i) * jitter
+        ctx.beginPath()
+        ctx.moveTo(Math.cos(angle) * radius * 0.8, Math.sin(angle) * radius * 0.8)
+        ctx.lineTo(Math.cos(angle) * len, Math.sin(angle) * len)
+        ctx.stroke()
+      }
+      ctx.restore()
     }
 
-    function animate(t) {
+    function loop(t) {
       draw(t)
-      animationFrame = requestAnimationFrame(animate)
+      frameId = requestAnimationFrame(loop)
     }
-    animate(0)
 
-    canvas.cleanup = () => cancelAnimationFrame(animationFrame)
+    loop(0)
+
+    canvas.cleanup = () => cancelAnimationFrame(frameId)
 
     return canvas
   }

--- a/glyphs/sol.js
+++ b/glyphs/sol.js
@@ -1,5 +1,16 @@
 const Sol = {
   name: 'sol',
+  behavior: {
+    identity: 'Sol',
+    presence: 'a luminous, centered awareness',
+    gesture: 'hands open to the sky',
+    motion: 'steady radiance',
+    meaning: 'illumination',
+    audio: 'shae_meditation.wav'
+  },
+  aesthetic: {
+    textColor: '#ffcc00'
+  },
   render: (opts = {}) => {
     const div = document.createElement('div')
     div.textContent = '☀'

--- a/prototypes/sol-test.html
+++ b/prototypes/sol-test.html
@@ -4,24 +4,48 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Sol Glyph Test</title>
+  <style>
+    body {
+      background: black;
+      color: white;
+      font-family: sans-serif;
+      text-align: center;
+      padding: 4vh 2vw;
+    }
+    .glyph-container {
+      margin: 4vh auto;
+      width: 300px;
+      height: 300px;
+    }
+  </style>
 </head>
 <body>
+  <h1>iamsol Glyph</h1>
+  <div class="glyph-container" id="glyph"></div>
+  <div id="meta"></div>
+
   <script type="module">
     import Codex from '../codex.js';
+    import { renderGlyph } from '../glyphs/glyphs.js';
+
     const sol = Codex.get('sol');
-    if (sol) {
-      document.body.style.background = 'black';
-      document.body.style.color = sol.aesthetic.textColor;
-      document.body.style.textAlign = 'center';
-      document.body.style.fontFamily = 'sans-serif';
-      document.body.style.paddingTop = '20vh';
-      document.body.innerHTML = `
-        <div style="font-size:2em;">This is the <strong>${sol.behavior.identity}</strong> glyph.</div>
-        <div style="margin-top:1em;">Behavior: ${sol.behavior.presence}</div>
-        <div style="margin-top:0.5em;">Audio: ${sol.behavior.audio}</div>
+    const meta = document.getElementById('meta');
+    const glyphEl = renderGlyph('iamsol');
+
+    if (glyphEl) {
+      document.getElementById('glyph').appendChild(glyphEl);
+    }
+
+    if (sol && sol.behavior) {
+      meta.innerHTML = `
+        <h2>${sol.behavior.identity}</h2>
+        <p><em>Presence:</em> ${sol.behavior.presence}</p>
+        <p><em>Gesture:</em> ${sol.behavior.gesture}</p>
+        <p><em>Motion:</em> ${sol.behavior.motion}</p>
+        <p><em>Meaning:</em> ${sol.behavior.meaning}</p>
       `;
     } else {
-      document.body.textContent = 'Sol glyph not registered.';
+      meta.textContent = 'Sol glyph not registered in codex.';
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- enrich `sol.js` with behavior and aesthetic metadata
- expand `iamsol.js` with a pulsing sun animation and metadata
- redesign `sol-test.html` to display metadata and the animated glyph

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68699b64af04832fbbf19c5281425977