### PR TITLE
Fix glyph variable in sol-test

### DIFF
--- a/prototypes/sol-test.html
+++ b/prototypes/sol-test.html
@@ -30,10 +30,10 @@
 
     const sol = Codex.get('sol');
     const meta = document.getElementById('meta');
-    const glyphEl = renderGlyph('iamsol');
+    const glyph = renderGlyph('iamsol');
 
-    if (glyphEl) {
-      document.getElementById('glyph').appendChild(glyphEl);
+    if (glyph) {
+      document.getElementById('glyph').appendChild(glyph);
     }
 
     if (sol && sol.behavior) {


### PR DESCRIPTION
## Summary
- update the prototype `sol-test.html` to use a consistent `glyph` variable

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6869b0226698832f857936077f494b0a