### PR TITLE
Implement animated iamsol glyph

### DIFF
--- a/glyphs/iamsol.js
+++ b/glyphs/iamsol.js
@@ -9,12 +9,52 @@ export default {
   },
   render: (opts = {}) => {
     const size = opts.size || 300
-    const img = document.createElement('img')
-    img.src = '../assets/sol-preview.png'
-    img.alt = 'Sol glyph'
-    img.width = size
-    img.height = size
-    img.classList.add('glyph', 'glyph-iamsol')
-    return img
+    const canvas = document.createElement('canvas')
+    canvas.width = size
+    canvas.height = size
+    canvas.classList.add('glyph', 'glyph-iamsol')
+
+    const ctx = canvas.getContext('2d')
+    let angle = 0
+
+    function draw() {
+      ctx.clearRect(0, 0, size, size)
+      const now = Date.now()
+      const baseRadius = size * 0.3
+      const pulse = Math.sin(now / 800) * (size * 0.03)
+      const radius = baseRadius + pulse
+
+      const grad = ctx.createRadialGradient(size / 2, size / 2, radius * 0.2, size / 2, size / 2, radius)
+      grad.addColorStop(0, '#fff8b0')
+      grad.addColorStop(1, '#fca85d')
+
+      ctx.fillStyle = grad
+      ctx.beginPath()
+      ctx.arc(size / 2, size / 2, radius, 0, Math.PI * 2)
+      ctx.fill()
+
+      const rayCount = 12
+      const rayLen = size * 0.45
+      ctx.lineWidth = 3
+      ctx.strokeStyle = '#ffe599'
+
+      ctx.save()
+      ctx.translate(size / 2, size / 2)
+      ctx.rotate(angle)
+      for (let i = 0; i < rayCount; i++) {
+        ctx.beginPath()
+        ctx.moveTo(0, radius)
+        ctx.lineTo(0, rayLen)
+        ctx.stroke()
+        ctx.rotate((Math.PI * 2) / rayCount)
+      }
+      ctx.restore()
+
+      angle += 0.01
+      requestAnimationFrame(draw)
+    }
+
+    draw()
+    return canvas
   }
 }

--- a/style/glyphs.css
+++ b/style/glyphs.css
@@ -45,3 +45,7 @@ body {
   stroke-linecap: round;
   stroke-linejoin: round;
 }
+.glyph-iamsol {
+  width: 300px;
+  height: 300px;
+}


### PR DESCRIPTION
## Summary
- animate the `iamsol` glyph using canvas drawing
- add basic CSS for the new glyph animation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6869c4318728832fa8ae66ea67966327